### PR TITLE
fix(query): tweak Update() method when no rows returned (#6)

### DIFF
--- a/pkg/pages/query.go
+++ b/pkg/pages/query.go
@@ -148,9 +148,16 @@ func (q *QueryPage) readAndQuery() {
 	log.Println(tableRowList)
 
 	// make sure to set culumn first!
-	q.DataTable.SetColumns(tableColumn)
-
-	if len(tableColumn) > 0 {
-		q.DataTable.SetRows(tableRowList)
+	if len(tableColumn) == 0 {
+		var c []table.Column
+		c = append(c, table.Column{Title: "Message", Width: 16})
+		var r []table.Row
+		r = append(r, table.Row{"No Rows Returned"})
+		q.DataTable.SetColumns(c)
+		q.DataTable.SetRows(r)
+		return
 	}
+
+	q.DataTable.SetColumns(tableColumn)
+	q.DataTable.SetRows(tableRowList)
 }


### PR DESCRIPTION
Steps to see this PR's update:

In the terminal
- Run `docker run -dt --name mysql -e MYSQL_ROOT_PASSWORD=rootpass -e MYSQL_DATABASE=mydatabase -p 3306:3306 mysql:8.0`
- Run `DEBUG=true ./dbterm`
- Type `mysql`
- Type `root:rootpass@tcp(localhost:3306)/mydatabase`
- Type `use mydatabase;`

Expected output:

```bash
Enter the input:

Select the database

> use mydatabase;

Querying the database
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ Message
┃──────────────────
┃ No Rows Returned
┃
┃
┃
┃
┃
┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

(esc to quit)
```