### PR TITLE
🔧 build(makefile): add three phony targets in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-clean:
+help: ## Show help message
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | column -s "##" -t
+
+clean: ## Clean the built binary
 	@find . -type f -name dbterm | xargs rm -f
 
-build:
+build: ## Build the main binary
 	@go build -ldflags "-s -w" -o dbterm cmd/main.go

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,9 @@ clean: ## Clean the built binary
 
 build: ## Build the main binary
 	@go build -ldflags "-s -w" -o dbterm cmd/main.go
+
+install-gofumpt: ## Install gofumpt
+	@go install mvdan.cc/gofumpt@latest
+
+style: ## Format the codebase
+	@gofumpt -l -w .


### PR DESCRIPTION
In this PR, three phony targets are added in `Makefile`: `help`, `install-gofumpt`, and `style`.

On the root of the project directory, `make help` (or just `make`) gives us the messages of all phony targets:

```console
$ make
help:               Show help message
clean:              Clean the built binary
build:              Build the main binary
install-gofumpt:    Install gofumpt
style:              Format the codebase
```

The other targets `install-gofumpt` and `style` are just helper commands.